### PR TITLE
Upgrade symfony/console to v5, remove unused symfony/event-dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/console": "~2.0 | ~3.0",
-        "symfony/event-dispatcher": "~2.6"
+        "symfony/console": "^2.0 | ^3.0 | ^4.0 | ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
symfony/event-dispatcher does not seem to be used in the code